### PR TITLE
fix: GetKubernetesClusterArgs type

### DIFF
--- a/sdk/nodejs/getKubernetesCluster.ts
+++ b/sdk/nodejs/getKubernetesCluster.ts
@@ -57,7 +57,7 @@ export function getKubernetesCluster(args: GetKubernetesClusterArgs, opts?: pulu
  * A collection of arguments for invoking getKubernetesCluster.
  */
 export interface GetKubernetesClusterArgs {
-    id: string;
+    id: pulumi.Input<string>;
 }
 
 /**


### PR DESCRIPTION
The any [here](https://github.com/UpCloudLtd/pulumi-upcloud/blob/af8d08a2544a2e9633cd4b27fc84785567fb3ea8/examples/db%2Bk8s/index.ts#L94) isn't necessary with this fixed type. Since it accepts `<T>`, it's also backwards compatible with plain strings.