### PR TITLE
chore: Simplify db+k8s example

### DIFF
--- a/examples/db+k8s/.gitignore
+++ b/examples/db+k8s/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /node_modules/
+.env*

--- a/examples/db+k8s/README.md
+++ b/examples/db+k8s/README.md
@@ -1,3 +1,8 @@
 # Database and Kubernetes cluster
 
 This example creates a Postgres database and a Kubernetes cluster using the UpCloud provider as well as deploys an example application ([cicd-tutorials/feedback](https://github.com/cicd-tutorials/feedback.git)) into the Kubernetes cluster so that it uses the created database as data storage.
+
+## Usage
+
+1. Make your token or credentials available in the environment [as described here](https://upcloud.com/docs/guides/get-started-terraform/#setting-up-upcloud-user-credentials).
+2. Run pulumi up twice. It will fail the first time because we can't depend on knowing when the cluster has become available. The second time, the app will be deployed. (In a production scenario, you will likely want to split infrastructure and apps into two different stacks anyway.)

--- a/examples/db+k8s/README.md
+++ b/examples/db+k8s/README.md
@@ -5,4 +5,5 @@ This example creates a Postgres database and a Kubernetes cluster using the UpCl
 ## Usage
 
 1. Make your token or credentials available in the environment [as described here](https://upcloud.com/docs/guides/get-started-terraform/#setting-up-upcloud-user-credentials).
-2. Run pulumi up twice. It will fail the first time because we can't depend on knowing when the cluster has become available. The second time, the app will be deployed. (In a production scenario, you will likely want to split infrastructure and apps into two different stacks anyway.)
+2. Run `pulumi up` twice. It will fail the first time because we can't depend on knowing when the cluster has become available. The second time, the app will be deployed. (In a production scenario, you will likely want to split infrastructure and apps into two different stacks anyway.)
+3. If you want to access the admin panel of the app, run `pulumi up` again to update the `initial_admin_password` output value.

--- a/examples/db+k8s/app.ts
+++ b/examples/db+k8s/app.ts
@@ -5,317 +5,277 @@ import * as k8s from "@pulumi/kubernetes";
 import * as k8sClient from "@kubernetes/client-node";
 
 interface FeedbackAppArgs {
-  /** Kubeconfig must be passed in as a string (instead of defining `opts.providers.kubernetes`) because it is also needed for initializing k8s node client library. */
   kubeconfig: string;
-  namespace?: pulumi.Input<string>;
+  namespaceName?: pulumi.Input<string>;
   serviceType?: pulumi.Input<string>;
   dbConnectUrl: pulumi.Input<string>;
   appVersion?: pulumi.Input<string>;
 }
 
-export class FeedbackApp extends pulumi.ComponentResource {
-  readonly namespace: k8s.core.v1.Namespace;
+async function getNodePortUrl(port: number, k8sApi?: k8sClient.CoreV1Api) {
+  const nodes = await k8sApi?.listNode();
+  const addresses = nodes?.items
+    .map((node) => {
+      const address = node.status?.addresses?.find(
+        (address) => address.type === "ExternalIP"
+      );
+      return address?.address;
+    })
+    .filter((address) => address !== undefined);
 
-  readonly apiSecret: k8s.core.v1.Secret;
-  readonly apiDeployment: k8s.apps.v1.Deployment;
-  readonly apiService: k8s.core.v1.Service;
+  const hostname = addresses?.[0] ?? "localhost";
+  return `http://${hostname}:${port}`;
+}
 
-  readonly uiConfigMap: k8s.core.v1.ConfigMap;
-  readonly uiDeployment: k8s.apps.v1.Deployment;
-  readonly uiService: k8s.core.v1.Service;
+async function readInitialAdminPassword(namespace: string, k8sApi?: k8sClient.CoreV1Api, k8sExec?: k8sClient.Exec): Promise<string> {
+  if (k8sApi === undefined || k8sExec === undefined) {
+    return "";
+  }
 
-  private k8sApi: k8sClient.CoreV1Api | undefined;
-  private k8sExec: k8sClient.Exec | undefined;
+  const pods = await k8sApi.listNamespacedPod({
+    namespace,
+  });
+  const pod = pods.items
+    .map((i) => i.metadata?.name)
+    .find((i) => i?.startsWith("api-"));
 
-  constructor(
-    name: string,
-    args: FeedbackAppArgs,
-    opts?: pulumi.ComponentResourceOptions
-  ) {
-    const { kubeconfig } = args;
-    super("pkg:index:FeedbackApp", name, args, {
-      ...opts,
-      providers: { kubernetes: new k8s.Provider("k8s", { kubeconfig }) },
+  if (!pod) {
+    return "";
+  }
+
+  const output = new PassThrough();
+  const done = new Promise<void>(async (resolve, reject) => {
+    if (k8sExec === undefined) {
+      reject();
+      return;
+    }
+
+    await k8sExec.exec(
+      namespace,
+      pod,
+      "api",
+      ["cat", "/var/feedback/initial_admin_password"],
+      output,
+      null,
+      null,
+      false,
+      () => {
+        void resolve();
+      }
+    );
+  });
+
+  try {
+    await done;
+    return output.read().toString("utf8").trim();
+  } catch (_) {
+    return "";
+  }
+}
+
+export function createFeedbackApp({
+  appVersion = "latest",
+  dbConnectUrl = "postgresql://user:pass@db:5432/feedback",
+  namespaceName = "feedback",
+  serviceType = "NodePort",
+  kubeconfig,
+}: FeedbackAppArgs, opts?: pulumi.ComponentResourceOptions) {
+  // `kubeconfig` is empty when previewing the stack before the cluster has been created.
+  let k8sApi: k8sClient.CoreV1Api | undefined;
+  let k8sExec: k8sClient.Exec | undefined;
+  if (kubeconfig) {
+    const kc = new k8sClient.KubeConfig();
+    kc.loadFromString(kubeconfig);
+    k8sApi = kc.makeApiClient(k8sClient.CoreV1Api);
+    k8sExec = new k8sClient.Exec(kc);
+  }
+
+  const { metadata: { name: namespace } } = new k8s.core.v1.Namespace("ns", {
+    metadata: {
+      name: namespaceName,
+    },
+  }, opts);
+
+  const apiSecret = new k8s.core.v1.Secret(
+    "api",
+    {
+      metadata: {
+        name: "api",
+        namespace,
+      },
+      stringData: {
+        DB_CONNECT_URL: dbConnectUrl,
+      },
+    },
+    opts
+  );
+
+  new k8s.core.v1.Service(
+    "api",
+    {
+      metadata: {
+        name: "api",
+        namespace,
+      },
+      spec: {
+        ports: [
+          {
+            port: 80,
+            targetPort: 8000,
+          },
+        ],
+        selector: { app: "api" },
+      },
+    },
+    opts
+  );
+
+  const uiConfigMap = new k8s.core.v1.ConfigMap(
+    "ui",
+    {
+      metadata: {
+        name: "ui",
+        namespace,
+      },
+      data: {
+        config: 'const serverUrl = "/api";',
+        resolver: "resolver coredns.kube-system.svc.cluster.local;",
+      },
+    },
+    opts
+  );
+
+  new k8s.apps.v1.Deployment(
+    "ui",
+    {
+      metadata: {
+        name: "ui",
+        namespace,
+        labels: {
+          app: "ui",
+        },
+      },
+      spec: {
+        selector: { matchLabels: { app: "ui" } },
+        template: {
+          metadata: { labels: { app: "ui" } },
+          spec: {
+            containers: [
+              {
+                name: "ui",
+                image: `ghcr.io/cicd-tutorials/feedback-ui:${appVersion}`,
+                env: [
+                  {
+                    name: "PROXY_PASS",
+                    value: `http://api.${namespaceName}.svc.cluster.local`,
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "ui",
+                    mountPath: "/usr/share/nginx/html/config.js",
+                    subPath: "config",
+                    readOnly: true,
+                  },
+                  {
+                    name: "ui",
+                    mountPath: "/etc/nginx/conf.d/resolver.conf",
+                    subPath: "resolver",
+                    readOnly: true,
+                  },
+                ],
+              },
+            ],
+            volumes: [
+              {
+                name: "ui",
+                configMap: {
+                  name: uiConfigMap.metadata.name,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    opts
+  );
+
+  const uiService = new k8s.core.v1.Service(
+    "ui",
+    {
+      metadata: {
+        name: "ui",
+        namespace,
+      },
+      spec: {
+        ports: [
+          {
+            port: serviceType === "LoadBalancer" ? 443 : 80,
+            targetPort: 80,
+          },
+        ],
+        selector: { app: "ui" },
+        type: serviceType,
+      },
+    },
+    opts
+  );
+
+  const url = pulumi
+    .all([uiService.spec, uiService.status])
+    .apply(async ([spec, status]) => {
+      const port = spec.ports[0].nodePort;
+      return spec.type === "LoadBalancer"
+        ? `https://${status.loadBalancer?.ingress?.[0].hostname}`
+        : await getNodePortUrl(port, k8sApi);
     });
 
-    // `kubeconfig` is empty when previewing the stack before the cluster has been created.
-    if (kubeconfig) {
-      const kc = new k8sClient.KubeConfig();
-      kc.loadFromString(kubeconfig);
-      this.k8sApi = kc.makeApiClient(k8sClient.CoreV1Api);
-      this.k8sExec = new k8sClient.Exec(kc);
-    }
-    const defaultDbConnectUrl = "postgresql://user:pass@db:5432/feedback";
-
-    const {
-      appVersion = "latest",
-      dbConnectUrl = defaultDbConnectUrl,
-      namespace = "feedback",
-      serviceType = "NodePort",
-    } = args;
-
-    this.namespace = new k8s.core.v1.Namespace(
-      "ns",
-      {
-        metadata: {
-          name: namespace,
+  new k8s.apps.v1.Deployment(
+    "api",
+    {
+      metadata: {
+        name: "api",
+        namespace,
+        labels: {
+          app: "api",
         },
       },
-      { parent: this }
-    );
-
-    this.apiSecret = new k8s.core.v1.Secret(
-      "api",
-      {
-        metadata: {
-          name: "api",
-          namespace: this.namespace.metadata.name,
-        },
-        stringData: {
-          DB_CONNECT_URL: dbConnectUrl,
-        },
-      },
-      { parent: this }
-    );
-
-    this.apiService = new k8s.core.v1.Service(
-      "api",
-      {
-        metadata: {
-          name: "api",
-          namespace: this.namespace.metadata.name,
-        },
-        spec: {
-          ports: [
-            {
-              port: 80,
-              targetPort: 8000,
-            },
-          ],
-          selector: { app: "api" },
-        },
-      },
-      { parent: this }
-    );
-
-    this.uiConfigMap = new k8s.core.v1.ConfigMap(
-      "ui",
-      {
-        metadata: {
-          name: "ui",
-          namespace: this.namespace.metadata.name,
-        },
-        data: {
-          config: 'const serverUrl = "/api";',
-          resolver: "resolver coredns.kube-system.svc.cluster.local;",
-        },
-      },
-      { parent: this, dependsOn: [this.apiService] }
-    );
-
-    this.uiDeployment = new k8s.apps.v1.Deployment(
-      "ui",
-      {
-        metadata: {
-          name: "ui",
-          namespace: this.namespace.metadata.name,
-          labels: {
-            app: "ui",
-          },
-        },
-        spec: {
-          selector: { matchLabels: { app: "ui" } },
-          template: {
-            metadata: { labels: { app: "ui" } },
-            spec: {
-              containers: [
-                {
-                  name: "ui",
-                  image: `ghcr.io/cicd-tutorials/feedback-ui:${appVersion}`,
-                  env: [
-                    {
-                      name: "PROXY_PASS",
-                      value: `http://api.${namespace}.svc.cluster.local`,
-                    },
-                  ],
-                  volumeMounts: [
-                    {
-                      name: "ui",
-                      mountPath: "/usr/share/nginx/html/config.js",
-                      subPath: "config",
-                      readOnly: true,
-                    },
-                    {
-                      name: "ui",
-                      mountPath: "/etc/nginx/conf.d/resolver.conf",
-                      subPath: "resolver",
-                      readOnly: true,
-                    },
-                  ],
-                },
-              ],
-              volumes: [
-                {
-                  name: "ui",
-                  configMap: {
-                    name: this.uiConfigMap.metadata.name,
+      spec: {
+        selector: { matchLabels: { app: "api" } },
+        template: {
+          metadata: { labels: { app: "api" } },
+          spec: {
+            containers: [
+              {
+                name: "api",
+                image: `ghcr.io/cicd-tutorials/feedback-api:${appVersion}`,
+                env: [
+                  {
+                    name: "FEEDBACK_URL",
+                    value: url,
                   },
-                },
-              ],
-            },
-          },
-        },
-      },
-      { parent: this }
-    );
-
-    const uiPort = serviceType === "LoadBalancer" ? 443 : 80;
-    this.uiService = new k8s.core.v1.Service(
-      "ui",
-      {
-        metadata: {
-          name: "ui",
-          namespace: this.namespace.metadata.name,
-        },
-        spec: {
-          ports: [
-            {
-              port: uiPort,
-              targetPort: 80,
-            },
-          ],
-          selector: { app: "ui" },
-          type: serviceType,
-        },
-      },
-      { parent: this }
-    );
-
-    this.apiDeployment = new k8s.apps.v1.Deployment(
-      "api",
-      {
-        metadata: {
-          name: "api",
-          namespace: this.namespace.metadata.name,
-          labels: {
-            app: "api",
-          },
-        },
-        spec: {
-          selector: { matchLabels: { app: "api" } },
-          template: {
-            metadata: { labels: { app: "api" } },
-            spec: {
-              containers: [
-                {
-                  name: "api",
-                  image: `ghcr.io/cicd-tutorials/feedback-api:${appVersion}`,
-                  env: [
-                    {
-                      name: "FEEDBACK_URL",
-                      value: this.url(),
-                    },
-                    {
-                      name: "FEEDBACK_DB_URL",
-                      valueFrom: {
-                        secretKeyRef: {
-                          name: this.apiSecret.metadata.name,
-                          key: "DB_CONNECT_URL",
-                        },
+                  {
+                    name: "FEEDBACK_DB_URL",
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: apiSecret.metadata.name,
+                        key: "DB_CONNECT_URL",
                       },
                     },
-                  ],
-                },
-              ],
-            },
+                  },
+                ],
+              },
+            ],
           },
         },
       },
-      { parent: this }
-    );
+    },
+    opts
+  );
 
-    this.registerOutputs({});
-  }
-
-  private async readInitialAdminPassword(namespace: string): Promise<string> {
-    if (this.k8sApi === undefined || this.k8sExec === undefined) {
-      return "";
-    }
-
-    const pods = await this.k8sApi.listNamespacedPod({
-      namespace,
-    });
-    const pod = pods.items
-      .map((i) => i.metadata?.name)
-      .find((i) => i?.startsWith("api-"));
-
-    if (!pod) {
-      return "";
-    }
-
-    const output = new PassThrough();
-    const done = new Promise<void>(async (resolve, reject) => {
-      if (this.k8sExec === undefined) {
-        reject();
-        return;
-      }
-
-      await this.k8sExec.exec(
-        namespace,
-        pod,
-        "api",
-        ["cat", "/var/feedback/initial_admin_password"],
-        output,
-        null,
-        null,
-        false,
-        () => {
-          void resolve();
-        }
-      );
-    });
-
-    try {
-      await done;
-      return output.read().toString("utf8").trim();
-    } catch (_) {
-      return "";
-    }
-  }
-
-  public initialAdminPassword(): pulumi.Output<string> {
-    return pulumi.secret(
-      this.namespace.metadata.apply((metadata) =>
-        this.readInitialAdminPassword(metadata.name)
-      )
-    );
-  }
-
-  private async getNodePortUrl(port: number) {
-    const nodes = await this.k8sApi?.listNode();
-    const addresses = nodes?.items
-      .map((i) => {
-        const address = i.status?.addresses?.find(
-          (j) => j.type === "ExternalIP"
-        );
-        return address?.address;
-      })
-      .filter((i) => i !== undefined);
-
-    const hostname = addresses?.[0] ?? "localhost";
-    return `http://${hostname}:${port}`;
-  }
-
-  public url(): pulumi.Output<string> {
-    return pulumi.output(
-      pulumi
-        .all([this.uiService.spec, this.uiService.status])
-        .apply(([spec, status]) => {
-          const port = spec.ports[0].nodePort;
-          return spec.type === "LoadBalancer"
-            ? `https://${status.loadBalancer?.ingress?.[0].hostname}`
-            : this.getNodePortUrl(port);
-        })
-    );
-  }
+  return {
+    url,
+    initialAdminPassword: pulumi.secret(namespace.apply((namespace) => readInitialAdminPassword(namespace, k8sApi, k8sExec))),
+  };
 }

--- a/examples/db+k8s/app.ts
+++ b/examples/db+k8s/app.ts
@@ -5,7 +5,7 @@ import * as k8s from "@pulumi/kubernetes";
 import * as k8sClient from "@kubernetes/client-node";
 
 interface FeedbackAppArgs {
-  kubeconfig: string;
+  kubeconfig: pulumi.Output<string>;
   namespaceName?: pulumi.Input<string>;
   serviceType?: pulumi.Input<string>;
   dbConnectUrl: pulumi.Input<string>;
@@ -83,12 +83,12 @@ export function createFeedbackApp({
   // `kubeconfig` is empty when previewing the stack before the cluster has been created.
   let k8sApi: k8sClient.CoreV1Api | undefined;
   let k8sExec: k8sClient.Exec | undefined;
-  if (kubeconfig) {
+  kubeconfig?.apply((asdf) => {
     const kc = new k8sClient.KubeConfig();
-    kc.loadFromString(kubeconfig);
+    kc.loadFromString(asdf);
     k8sApi = kc.makeApiClient(k8sClient.CoreV1Api);
     k8sExec = new k8sClient.Exec(kc);
-  }
+  });
 
   const { metadata: { name: namespace } } = new k8s.core.v1.Namespace("ns", {
     metadata: {

--- a/examples/db+k8s/app.ts
+++ b/examples/db+k8s/app.ts
@@ -83,9 +83,9 @@ export function createFeedbackApp({
   // `kubeconfig` is empty when previewing the stack before the cluster has been created.
   let k8sApi: k8sClient.CoreV1Api | undefined;
   let k8sExec: k8sClient.Exec | undefined;
-  kubeconfig?.apply((asdf) => {
+  kubeconfig?.apply((value) => {
     const kc = new k8sClient.KubeConfig();
-    kc.loadFromString(asdf);
+    kc.loadFromString(value);
     k8sApi = kc.makeApiClient(k8sClient.CoreV1Api);
     k8sExec = new k8sClient.Exec(kc);
   });

--- a/examples/db+k8s/index.ts
+++ b/examples/db+k8s/index.ts
@@ -1,119 +1,115 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as upcloud from "@upcloud/pulumi-upcloud";
+import * as k8s from "@pulumi/kubernetes";
 
-import { FeedbackApp } from "./app";
+import { createFeedbackApp } from "./app.ts";
 
-const main = async () => {
-  const config = new pulumi.Config();
+const config = new pulumi.Config();
 
-  // Common configuration
-  const prefix = config.get("prefix") ?? "pulumi-example-feedback";
-  const zone = config.get("zone") ?? "se-sto1";
+// Common configuration
+const prefix = config.get("prefix") ?? "pulumi-example-feedback";
+const zone = config.get("zone") ?? "se-sto1";
 
-  // Database configuration
-  const dbPlan = config.get("database-plan") ?? "1x2xCPU-4GB-50GB";
+// Database configuration
+const dbPlan = config.get("database-plan") ?? "1x1xCPU-1GB-10GB";
 
-  // Network configuration
-  const netCidr = config.get("network-cidr") ?? "172.24.0.0/24";
+// Network configuration
+const netCidr = config.get("network-cidr") ?? "172.24.0.0/24";
 
-  // Kubernetes configuration
-  const privateNodeGroups = config.getBoolean("private-node-groups") ?? true;
+// Kubernetes configuration
+const privateNodeGroups = config.getBoolean("private-node-groups") ?? true;
 
-  // Application configuration
-  const appVersion = config.get("app-version") ?? "latest";
-  const namespace = config.get("namespace") ?? "feedback";
-  const serviceType = config.get("service-type") ?? "LoadBalancer";
+// Application configuration
+const appVersion = config.get("app-version") ?? "latest";
+const namespace = config.get("namespace") ?? "feedback";
+const serviceType = config.get("service-type") ?? "LoadBalancer";
 
-  const withPrefix = (name: string) => `${prefix}-${name}`;
+const withPrefix = (name: string) => `${prefix}-${name}`;
 
-  const router = new upcloud.Router("router", {
-    name: withPrefix("router"),
+const router = new upcloud.Router("router", {
+  name: withPrefix("router"),
+});
+
+const network = new upcloud.Network("net", {
+  name: withPrefix("net"),
+  router: router.id,
+  zone,
+  ipNetwork: {
+    address: netCidr,
+    dhcp: true,
+    dhcpDefaultRoute: privateNodeGroups,
+    family: "IPv4",
+  },
+});
+
+if (privateNodeGroups) {
+  new upcloud.Gateway("natgw", {
+    name: withPrefix("gw"),
+    plan: "essentials",
+    zone,
+    features: ["nat"],
+    router: {
+      id: router.id,
+    },
   });
+}
 
-  const net = new upcloud.Network("net", {
-    name: withPrefix("net"),
-    router: router.id,
-    zone: zone,
-    ipNetwork: {
-      address: netCidr,
-      dhcp: true,
-      dhcpDefaultRoute: privateNodeGroups,
+const db = new upcloud.ManagedDatabasePostgresql("db", {
+  name: prefix,
+  title: withPrefix("db"),
+  plan: dbPlan,
+  zone,
+  networks: [
+    {
+      name: network.name,
       family: "IPv4",
+      type: "private",
+      uuid: network.id,
     },
-  });
+  ],
+  properties: {
+    publicAccess: false,
+  },
+});
 
-  let natgw: upcloud.Gateway | undefined = undefined;
-  if (privateNodeGroups) {
-    natgw = new upcloud.Gateway("natgw", {
-      name: withPrefix("gw"),
-      plan: "development",
-      zone: zone,
-      features: ["nat"],
-      router: {
-        id: router.id,
-      },
-    });
-  }
+const k8sCluster = new upcloud.KubernetesCluster("k8s-cluster", {
+  controlPlaneIpFilters: ["0.0.0.0/0"],
+  name: withPrefix("k8s"),
+  plan: "dev-md",
+  zone: zone,
+  network: network.id,
+  privateNodeGroups,
+  storageEncryption: "data-at-rest",
+});
 
-  const db = new upcloud.ManagedDatabasePostgresql("db", {
-    name: prefix,
-    title: withPrefix("db"),
-    plan: dbPlan,
-    zone: zone,
-    networks: [
-      {
-        name: net.name,
-        family: "IPv4",
-        type: "private",
-        uuid: net.id,
-      },
-    ],
-    properties: {
-      publicAccess: false,
-    },
-  });
+const k8sNodeGroup = new upcloud.KubernetesNodeGroup("k8s-node-group", {
+  cluster: k8sCluster.id,
+  name: "default",
+  nodeCount: 1,
+  plan: "DEV-1xCPU-2GB",
+});
 
-  const k8sCluster = new upcloud.KubernetesCluster("k8s-cluster", {
-    controlPlaneIpFilters: ["0.0.0.0/0"],
-    name: withPrefix("k8s"),
-    plan: "dev-md",
-    zone: zone,
-    network: net.id,
-    privateNodeGroups,
-    storageEncryption: "data-at-rest",
-  });
+const k8sOutput = upcloud.getKubernetesClusterOutput({
+  id: k8sCluster.id,
+});
 
-  const k8sNodeGroup = new upcloud.KubernetesNodeGroup("k8s-node-group", {
-    cluster: k8sCluster.id,
-    name: "default",
-    nodeCount: 1,
-    plan: "2xCPU-4GB",
-  });
-
-  const k8sClusterInfo = await upcloud.getKubernetesCluster({
-    // The `id` field accepts `pulumi.Input<string>` type even though the interface defines it as `string`. Cast `k8sCluster.id` to `any` to avoid type error.
-    id: k8sCluster.id as any,
-  });
-
-  const kubeconfig = k8sClusterInfo.kubeconfig;
-  const app = new FeedbackApp("app", {
+const { url, initialAdminPassword } = k8sOutput.kubeconfig.apply((kubeconfig) => {
+  return createFeedbackApp({
     appVersion,
     kubeconfig,
-    namespace,
+    namespaceName: namespace,
     serviceType,
     dbConnectUrl: db.serviceUri,
   }, {
+    provider: new k8s.Provider("k8s", { kubeconfig }),
     // Delete the app before deleting the cluster and the node group. While the app also depends on the database, that dependency does not prevent creating or deleting the kubernetes resources.
     dependsOn: [k8sCluster, k8sNodeGroup],
   });
+});
 
-  const url = app.url();
-  return {
-    form: url.apply((url) => `${url}/thumbs`),
-    admin_panel: url.apply((url) => `${url}/admin`),
-    admin_username: "admin",
-    initial_admin_password: app.initialAdminPassword(),
-  };
+export default {
+  form: url.apply((url) => `${url}/thumbs`),
+  admin_panel: url.apply((url) => `${url}/admin`),
+  admin_username: "admin",
+  initial_admin_password: initialAdminPassword,
 };
-
-export default main();

--- a/examples/db+k8s/index.ts
+++ b/examples/db+k8s/index.ts
@@ -93,18 +93,16 @@ const k8sOutput = upcloud.getKubernetesClusterOutput({
   id: k8sCluster.id,
 });
 
-const { url, initialAdminPassword } = k8sOutput.kubeconfig.apply((kubeconfig) => {
-  return createFeedbackApp({
-    appVersion,
-    kubeconfig,
-    namespaceName: namespace,
-    serviceType,
-    dbConnectUrl: db.serviceUri,
-  }, {
-    provider: new k8s.Provider("k8s", { kubeconfig }),
-    // Delete the app before deleting the cluster and the node group. While the app also depends on the database, that dependency does not prevent creating or deleting the kubernetes resources.
-    dependsOn: [k8sCluster, k8sNodeGroup],
-  });
+const { url, initialAdminPassword } = createFeedbackApp({
+  appVersion,
+  kubeconfig: k8sOutput.kubeconfig,
+  namespaceName: namespace,
+  serviceType,
+  dbConnectUrl: db.serviceUri,
+}, {
+  provider: new k8s.Provider("k8s", { kubeconfig: k8sOutput.kubeconfig }),
+  // Delete the app before deleting the cluster and the node group. While the app also depends on the database, that dependency does not prevent creating or deleting the kubernetes resources.
+  dependsOn: [k8sCluster, k8sNodeGroup],
 });
 
 export default {

--- a/examples/db+k8s/package-lock.json
+++ b/examples/db+k8s/package-lock.json
@@ -6,20 +6,30 @@
         "": {
             "name": "upcloud-typescript",
             "dependencies": {
-                "@kubernetes/client-node": "^1.1.2",
+                "@kubernetes/client-node": "^1.4.0",
                 "@pulumi/kubernetes": "^4.28.0",
-                "@pulumi/pulumi": "^3.0.0",
-                "@upcloud/pulumi-upcloud": "^0.2.0"
+                "@pulumi/pulumi": "^3.224.0",
+                "@upcloud/pulumi-upcloud": "^0.11.1"
             },
             "devDependencies": {
-                "@types/node": "^18.0.0",
-                "typescript": "^5.0.0"
+                "@types/node": "^18.19.130",
+                "typescript": "^5.9.3"
+            }
+        },
+        "node_modules/@gar/promise-retry": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+            "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@grpc/grpc-js": {
             "version": "1.14.3",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
             "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.8.0",
                 "@js-sdsl/ordered-map": "^4.4.2"
@@ -29,13 +39,14 @@
             }
         },
         "node_modules/@grpc/proto-loader": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
-            "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+            "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "lodash.camelcase": "^4.3.0",
                 "long": "^5.0.0",
-                "protobufjs": "^7.5.3",
+                "protobufjs": "^7.5.5",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -58,6 +69,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
             "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.4"
             },
@@ -68,12 +80,14 @@
         "node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
-            "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="
+            "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+            "license": "ISC"
         },
         "node_modules/@js-sdsl/ordered-map": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
             "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/js-sdsl"
@@ -83,6 +97,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
             "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 10.16.0"
             },
@@ -94,6 +109,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
             "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 10.16.0"
             },
@@ -105,6 +121,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
             "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@types/js-yaml": "^4.0.1",
                 "@types/node": "^24.0.0",
@@ -125,9 +142,10 @@
             }
         },
         "node_modules/@kubernetes/client-node/node_modules/@types/node": {
-            "version": "24.10.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
-            "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
+            "version": "24.12.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+            "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+            "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -135,12 +153,14 @@
         "node_modules/@kubernetes/client-node/node_modules/undici-types": {
             "version": "7.16.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "license": "MIT"
         },
         "node_modules/@logdna/tail-file": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@logdna/tail-file/-/tail-file-2.2.0.tgz",
             "integrity": "sha512-XGSsWDweP80Fks16lwkAUIr54ICyBs6PsI4mpfTLQaWgEJRtY9xEV+PeyDpJ+sJEGZxqINlpmAwe/6tS1pP8Ng==",
+            "license": "SEE LICENSE IN LICENSE",
             "engines": {
                 "node": ">=10.3.0"
             }
@@ -149,6 +169,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
             "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+            "license": "ISC",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "http-proxy-agent": "^7.0.0",
@@ -161,10 +182,12 @@
             }
         },
         "node_modules/@npmcli/arborist": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.3.0.tgz",
-            "integrity": "sha512-+iH0S4YZBsSgItmFWJsxbxtuFmaldGG8h9hQfCHeYHQxFZuIKD8NZB960c22OeFtQnI0FcuGLRA+sWQ3/4EEHQ==",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.5.0.tgz",
+            "integrity": "sha512-qS+TtKWC58sjBjD+szLrhEj2TCLnwzUA9vlMyCnU9ztw01ZjQSu25iQPxeBa0sk9sS9/Hzs/xJMWl7J/vRCjGQ==",
+            "license": "ISC",
             "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
                 "@isaacs/string-locale-compare": "^1.1.0",
                 "@npmcli/fs": "^5.0.0",
                 "@npmcli/installed-package-contents": "^4.0.0",
@@ -210,6 +233,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
             "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+            "license": "ISC",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -218,16 +242,17 @@
             }
         },
         "node_modules/@npmcli/git": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.1.tgz",
-            "integrity": "sha512-+XTFxK2jJF/EJJ5SoAzXk3qwIDfvFc5/g+bD274LZ7uY7LE8sTfG6Z8rOanPl2ZEvZWqNvmEdtXC25cE54VcoA==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+            "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "license": "ISC",
             "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
                 "@npmcli/promise-spawn": "^9.0.0",
                 "ini": "^6.0.0",
                 "lru-cache": "^11.2.1",
                 "npm-pick-manifest": "^11.0.1",
                 "proc-log": "^6.0.0",
-                "promise-retry": "^2.0.1",
                 "semver": "^7.3.5",
                 "which": "^6.0.0"
             },
@@ -239,6 +264,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
             "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -247,6 +273,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
             "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+            "license": "ISC",
             "dependencies": {
                 "npm-bundled": "^5.0.0",
                 "npm-normalize-package-bin": "^5.0.0"
@@ -262,6 +289,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
             "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/name-from-folder": "^4.0.0",
                 "@npmcli/package-json": "^7.0.0",
@@ -273,16 +301,17 @@
             }
         },
         "node_modules/@npmcli/map-workspaces/node_modules/glob": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
-            "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.2.0",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -292,6 +321,7 @@
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
             "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+            "license": "ISC",
             "dependencies": {
                 "cacache": "^20.0.0",
                 "json-parse-even-better-errors": "^5.0.0",
@@ -307,6 +337,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
             "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -315,14 +346,16 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
             "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@npmcli/package-json": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.4.tgz",
-            "integrity": "sha512-0wInJG3j/K40OJt/33ax47WfWMzZTm6OQxB9cDhTt5huCP2a9g2GnlsxmfN+PulItNPIpPrZ+kfwwUil7eHcZQ==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+            "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/git": "^7.0.0",
                 "glob": "^13.0.0",
@@ -330,23 +363,24 @@
                 "json-parse-even-better-errors": "^5.0.0",
                 "proc-log": "^6.0.0",
                 "semver": "^7.5.3",
-                "validate-npm-package-license": "^3.0.4"
+                "spdx-expression-parse": "^4.0.0"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@npmcli/package-json/node_modules/glob": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
-            "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.2.0",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -356,6 +390,7 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
             "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "license": "ISC",
             "dependencies": {
                 "which": "^6.0.0"
             },
@@ -367,6 +402,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
             "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+            "license": "ISC",
             "dependencies": {
                 "postcss-selector-parser": "^7.0.0"
             },
@@ -378,38 +414,41 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
             "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@npmcli/run-script": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.3.tgz",
-            "integrity": "sha512-ER2N6itRkzWbbtVmZ9WKaWxVlKlOeBFF1/7xx+KA5J1xKa4JjUwBdb6tDpk0v1qA+d+VDwHI9qmLcXSWcmi+Rw==",
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
+            "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/node-gyp": "^5.0.0",
                 "@npmcli/package-json": "^7.0.0",
                 "@npmcli/promise-spawn": "^9.0.0",
                 "node-gyp": "^12.1.0",
-                "proc-log": "^6.0.0",
-                "which": "^6.0.0"
+                "proc-log": "^6.0.0"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@opentelemetry/api": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=8.0.0"
             }
         },
         "node_modules/@opentelemetry/api-logs": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.55.0.tgz",
-            "integrity": "sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==",
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
             },
@@ -421,6 +460,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
             "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
             },
@@ -432,6 +472,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
             "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "1.28.0"
             },
@@ -442,10 +483,32 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.2.tgz",
+            "integrity": "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/exporter-zipkin": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.30.1.tgz",
             "integrity": "sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "1.30.1",
                 "@opentelemetry/resources": "1.30.1",
@@ -460,11 +523,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.55.0.tgz",
-            "integrity": "sha512-YDCMlaQRZkziLL3t6TONRgmmGxDx6MyQDXRD0dknkkgUZtOK5+8MWft1OXzmNu6XfBOdT12MKN5rz+jHUkafKQ==",
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.55.0",
+                "@opentelemetry/api-logs": "0.57.2",
                 "@types/shimmer": "^1.2.0",
                 "import-in-the-middle": "^1.8.1",
                 "require-in-the-middle": "^7.1.1",
@@ -479,12 +543,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-grpc": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.55.0.tgz",
-            "integrity": "sha512-n2ZH4pRwOy0Vhag/3eKqiyDBwcpUnGgJI9iiIRX7vivE0FMncaLazWphNFezRRaM/LuKwq1TD8pVUvieP68mow==",
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.57.2.tgz",
+            "integrity": "sha512-TR6YQA67cLSZzdxbf2SrbADJy2Y8eBW1+9mF15P0VK2MYcpdoUSmQTF1oMkBwa3B9NwqDFA2fq7wYTTutFQqaQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "0.55.0",
-                "@opentelemetry/semantic-conventions": "1.27.0"
+                "@opentelemetry/instrumentation": "0.57.2",
+                "@opentelemetry/semantic-conventions": "1.28.0"
             },
             "engines": {
                 "node": ">=14"
@@ -493,18 +558,66 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.27.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-            "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+        "node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
+            "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-transformer": "0.57.2"
+            },
             "engines": {
                 "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
+            "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.7.1",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/otlp-exporter-base": "0.57.2",
+                "@opentelemetry/otlp-transformer": "0.57.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+            "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/sdk-logs": "0.57.2",
+                "@opentelemetry/sdk-metrics": "1.30.1",
+                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "protobufjs": "^7.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/propagator-b3": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
             "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "1.30.1"
             },
@@ -519,6 +632,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
             "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "1.30.1"
             },
@@ -533,6 +647,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
             "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "1.30.1",
                 "@opentelemetry/semantic-conventions": "1.28.0"
@@ -544,10 +659,44 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
+        "node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+            "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+            "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
         "node_modules/@opentelemetry/sdk-trace-base": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
             "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "1.30.1",
                 "@opentelemetry/resources": "1.30.1",
@@ -564,6 +713,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
             "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/context-async-hooks": "1.30.1",
                 "@opentelemetry/core": "1.30.1",
@@ -583,6 +733,7 @@
             "version": "1.28.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
             "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
             }
@@ -590,27 +741,32 @@
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
             "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.1",
                 "@protobufjs/inquire": "^1.1.0"
@@ -619,32 +775,37 @@
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@pulumi/kubernetes": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-4.28.0.tgz",
-            "integrity": "sha512-tdoUN7blJv1rrwr+2Pc55CP/+L1sMkH3z5Y7DI2yfNiGgdeaOHYia+hYsnLgR4HtBSfIfuBVWxGkZwGWOgUmOQ==",
+            "version": "4.30.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-4.30.0.tgz",
+            "integrity": "sha512-ZCS4HwBvcxfdPDw44L1/SCqoIttCVugx/FZzqRFRq+leKRIfigAYt4sILXlqulNtX6XjlWVzZO8zva3Ygk7hGA==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -654,33 +815,33 @@
             }
         },
         "node_modules/@pulumi/pulumi": {
-            "version": "3.220.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.220.0.tgz",
-            "integrity": "sha512-WfFu4Qv5r/9uv4bh6jxZPKLc945RtdjIq29mDa6c9sIXzQtRtv/Voo58E6u6lhA1RKaK+ocymqgykZ6QV7OnGQ==",
+            "version": "3.237.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.237.0.tgz",
+            "integrity": "sha512-sSha6qfV1dcLP6OkqLKyM1UdzKRLfcAsHfhAUiXhlSHia+Grsso1Zvq0ZByj44nK9sY98BLlPlQBtt1VRWHZOQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.1",
                 "@logdna/tail-file": "^2.0.6",
                 "@npmcli/arborist": "^9.0.0",
                 "@opentelemetry/api": "^1.9",
-                "@opentelemetry/exporter-zipkin": "^1.28",
-                "@opentelemetry/instrumentation": "^0.55",
-                "@opentelemetry/instrumentation-grpc": "^0.55",
-                "@opentelemetry/resources": "^1.28",
-                "@opentelemetry/sdk-trace-base": "^1.28",
-                "@opentelemetry/sdk-trace-node": "^1.28",
+                "@opentelemetry/exporter-trace-otlp-grpc": "^0.57",
+                "@opentelemetry/exporter-zipkin": "^1.30",
+                "@opentelemetry/instrumentation": "^0.57",
+                "@opentelemetry/instrumentation-grpc": "^0.57",
+                "@opentelemetry/resources": "^1.30",
+                "@opentelemetry/sdk-trace-base": "^1.30",
+                "@opentelemetry/sdk-trace-node": "^1.30",
                 "@types/google-protobuf": "^3.15.5",
                 "@types/semver": "^7.5.6",
                 "@types/tmp": "^0.2.6",
                 "execa": "^5.1.0",
                 "fdir": "^6.5.0",
                 "google-protobuf": "^3.21.4",
-                "got": "^11.8.6",
                 "ini": "^2.0.0",
                 "js-yaml": "^3.14.2",
                 "minimist": "^1.2.6",
                 "normalize-package-data": "^6.0.0",
-                "package-directory": "^8.1.0",
-                "picomatch": "^3.0.1",
+                "picomatch": "^4.0.0",
                 "require-from-string": "^2.0.1",
                 "semver": "^7.5.2",
                 "source-map-support": "^0.5.6",
@@ -692,7 +853,7 @@
             },
             "peerDependencies": {
                 "ts-node": ">= 7.0.1 < 12",
-                "typescript": ">= 3.8.3 < 6"
+                "typescript": ">= 3.8.3 < 7"
             },
             "peerDependenciesMeta": {
                 "ts-node": {
@@ -707,6 +868,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -715,6 +877,7 @@
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
             "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -727,6 +890,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
             "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.5.0"
             },
@@ -735,41 +899,45 @@
             }
         },
         "node_modules/@sigstore/core": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.1.0.tgz",
-            "integrity": "sha512-o5cw1QYhNQ9IroioJxpzexmPjfCe7gzafd2RY3qnMpxr4ZEja+Jad/U8sgFpaue6bOaF+z7RVkyKVV44FN+N8A==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@sigstore/protobuf-specs": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.0.tgz",
-            "integrity": "sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+            "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/@sigstore/sign": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.0.tgz",
-            "integrity": "sha512-Vx1RmLxLGnSUqx/o5/VsCjkuN5L7y+vxEEwawvc7u+6WtX2W4GNa7b9HEjmcRWohw/d6BpATXmvOwc78m+Swdg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+            "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+            "license": "Apache-2.0",
             "dependencies": {
+                "@gar/promise-retry": "^1.0.2",
                 "@sigstore/bundle": "^4.0.0",
-                "@sigstore/core": "^3.1.0",
+                "@sigstore/core": "^3.2.0",
                 "@sigstore/protobuf-specs": "^0.5.0",
-                "make-fetch-happen": "^15.0.3",
-                "proc-log": "^6.1.0",
-                "promise-retry": "^2.0.1"
+                "make-fetch-happen": "^15.0.4",
+                "proc-log": "^6.1.0"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/@sigstore/tuf": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.1.tgz",
-            "integrity": "sha512-OPZBg8y5Vc9yZjmWCHrlWPMBqW5yd8+wFNl+thMdtcWz3vjVSoJQutF8YkrzI0SLGnkuFof4HSsWUhXrf219Lw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+            "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.5.0",
                 "tuf-js": "^4.1.0"
@@ -782,6 +950,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.0.tgz",
             "integrity": "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^4.0.0",
                 "@sigstore/core": "^3.1.0",
@@ -791,32 +960,11 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/@sindresorhus/is": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-            "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-            "dependencies": {
-                "defer-to-connect": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@tufjs/canonical-json": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
             "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+            "license": "MIT",
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
             }
@@ -825,6 +973,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
             "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+            "license": "MIT",
             "dependencies": {
                 "@tufjs/canonical-json": "2.0.0",
                 "minimatch": "^10.1.1"
@@ -833,44 +982,23 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/@types/cacheable-request": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-            "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-            "dependencies": {
-                "@types/http-cache-semantics": "*",
-                "@types/keyv": "^3.1.4",
-                "@types/node": "*",
-                "@types/responselike": "^1.0.0"
-            }
-        },
         "node_modules/@types/google-protobuf": {
             "version": "3.15.12",
             "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
-            "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ=="
-        },
-        "node_modules/@types/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="
+            "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==",
+            "license": "MIT"
         },
         "node_modules/@types/js-yaml": {
             "version": "4.0.9",
             "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-            "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
-        },
-        "node_modules/@types/keyv": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-            "dependencies": {
-                "@types/node": "*"
-            }
+            "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "18.19.130",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
             "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -879,33 +1007,29 @@
             "version": "2.6.13",
             "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
             "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "form-data": "^4.0.4"
             }
         },
-        "node_modules/@types/responselike": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-            "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/semver": {
             "version": "7.7.1",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+            "license": "MIT"
         },
         "node_modules/@types/shimmer": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+            "license": "MIT"
         },
         "node_modules/@types/stream-buffers": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
             "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -913,12 +1037,14 @@
         "node_modules/@types/tmp": {
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
-            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA=="
+            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+            "license": "MIT"
         },
         "node_modules/@upcloud/pulumi-upcloud": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@upcloud/pulumi-upcloud/-/pulumi-upcloud-0.2.0.tgz",
-            "integrity": "sha512-t00Jf3jsyvSPTLFsNHYi6ue6R8qcNM8NA6vYtSixPF0WheQzB2E5PtTJ8509yfCNRvUhxocMilpOe8fRSGA5GQ==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@upcloud/pulumi-upcloud/-/pulumi-upcloud-0.11.1.tgz",
+            "integrity": "sha512-uqjOAQGo/5oznzrTsOuxlFqXd5PLGIvpYWMdzDeYGjVu5S/+HMGAzxzSQ7MJJbjdHLUsdaY1DZoIYFZTvlpB2g==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@pulumi/pulumi": "^3.142.0"
             }
@@ -927,14 +1053,16 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
             "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -946,6 +1074,7 @@
             "version": "1.9.5",
             "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
             "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "license": "MIT",
             "peerDependencies": {
                 "acorn": "^8"
             }
@@ -954,24 +1083,52 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
         },
         "node_modules/b4a": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.4.tgz",
-            "integrity": "sha512-u20zJLDaSWpxaZ+zaAkEIB2dZZ1o+DF4T/MRbmsvGp9nletHOyiai19OzX1fF8xUBYsO1bPXxODvcd0978pnug==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+            "license": "Apache-2.0",
             "peerDependencies": {
                 "react-native-b4a": "*"
             },
@@ -982,20 +1139,19 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-            "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-            "dependencies": {
-                "jackspeak": "^4.2.3"
-            },
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/bare-events": {
             "version": "2.8.2",
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
             "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+            "license": "Apache-2.0",
             "peerDependencies": {
                 "bare-abort-controller": "*"
             },
@@ -1006,10 +1162,10 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.4.tgz",
-            "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
-            "optional": true,
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+            "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
@@ -1030,10 +1186,10 @@
             }
         },
         "node_modules/bare-os": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-            "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
-            "optional": true,
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+            "license": "Apache-2.0",
             "engines": {
                 "bare": ">=1.14.0"
             }
@@ -1042,24 +1198,29 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
             "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-            "optional": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "bare-os": "^3.0.1"
             }
         },
         "node_modules/bare-stream": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-            "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
-            "optional": true,
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "streamx": "^2.21.0"
+                "streamx": "^2.25.0",
+                "teex": "^1.0.1"
             },
             "peerDependencies": {
+                "bare-abort-controller": "*",
                 "bare-buffer": "*",
                 "bare-events": "*"
             },
             "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                },
                 "bare-buffer": {
                     "optional": true
                 },
@@ -1069,10 +1230,10 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-            "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-            "optional": true,
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "bare-path": "^3.0.0"
             }
@@ -1081,6 +1242,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
             "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+            "license": "ISC",
             "dependencies": {
                 "cmd-shim": "^8.0.0",
                 "npm-normalize-package-bin": "^5.0.0",
@@ -1093,25 +1255,28 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-            "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "license": "MIT"
         },
         "node_modules/cacache": {
-            "version": "20.0.3",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
-            "integrity": "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==",
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^5.0.0",
                 "fs-minipass": "^3.0.0",
@@ -1122,72 +1287,34 @@
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
                 "p-map": "^7.0.2",
-                "ssri": "^13.0.0",
-                "unique-filename": "^5.0.0"
+                "ssri": "^13.0.0"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/cacache/node_modules/glob": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
-            "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.2.0",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/cacheable-lookup": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-            "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-            "engines": {
-                "node": ">=10.6.0"
-            }
-        },
-        "node_modules/cacheable-request": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-            "dependencies": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^4.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^6.0.1",
-                "responselike": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -1200,6 +1327,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
             "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
             }
@@ -1207,12 +1335,14 @@
         "node_modules/cjs-module-lexer": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -1222,88 +1352,11 @@
                 "node": ">=12"
             }
         },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/clone-response": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/cmd-shim": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
             "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -1312,6 +1365,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -1322,12 +1376,14 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -1339,6 +1395,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
             "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">= 18"
             }
@@ -1347,6 +1404,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -1359,12 +1417,14 @@
         "node_modules/cross-spawn/node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
         },
         "node_modules/cross-spawn/node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -1379,6 +1439,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
             },
@@ -1390,6 +1451,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -1402,43 +1464,11 @@
                 }
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decompress-response/node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1447,6 +1477,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -1456,19 +1487,17 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/encoding": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "optional": true,
-            "dependencies": {
-                "iconv-lite": "^0.6.2"
-            }
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
         },
         "node_modules/end-of-stream": {
             "version": "1.4.5",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
             "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -1477,19 +1506,16 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/err-code": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -1498,6 +1524,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -1506,6 +1533,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -1517,6 +1545,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -1531,6 +1560,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -1539,6 +1569,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -1551,6 +1582,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
             "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "bare-events": "^2.7.0"
             }
@@ -1559,6 +1591,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -1580,17 +1613,20 @@
         "node_modules/exponential-backoff": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="
+            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+            "license": "Apache-2.0"
         },
         "node_modules/fast-fifo": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "license": "MIT"
         },
         "node_modules/fdir": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -1601,17 +1637,6 @@
                 "picomatch": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/find-up-simple": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
-            "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/foreground-child": {
@@ -1646,6 +1671,7 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
             "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -1661,6 +1687,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
             "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+            "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
             },
@@ -1672,6 +1699,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -1680,6 +1708,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -1688,6 +1717,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
@@ -1711,6 +1741,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -1723,6 +1754,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -1756,12 +1788,14 @@
         "node_modules/google-protobuf": {
             "version": "3.21.4",
             "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
-            "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ=="
+            "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+            "license": "(BSD-3-Clause AND Apache-2.0)"
         },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1769,39 +1803,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/got": {
-            "version": "11.8.6",
-            "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-            "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-            "dependencies": {
-                "@sindresorhus/is": "^4.0.0",
-                "@szmarczak/http-timer": "^4.0.5",
-                "@types/cacheable-request": "^6.0.1",
-                "@types/responselike": "^1.0.0",
-                "cacheable-lookup": "^5.0.3",
-                "cacheable-request": "^7.0.2",
-                "decompress-response": "^6.0.0",
-                "http2-wrapper": "^1.0.0-beta.5.2",
-                "lowercase-keys": "^2.0.0",
-                "p-cancelable": "^2.0.0",
-                "responselike": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/got?sponsor=1"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "license": "ISC"
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -1813,6 +1825,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -1824,9 +1837,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -1835,9 +1849,10 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-            "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^11.1.0"
             },
@@ -1849,6 +1864,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
             "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
@@ -1856,12 +1872,14 @@
         "node_modules/http-cache-semantics": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -1870,22 +1888,11 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/http2-wrapper": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-            "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-            "dependencies": {
-                "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
-            }
-        },
         "node_modules/https-proxy-agent": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -1898,26 +1905,33 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ignore-walk": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
             "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+            "license": "ISC",
             "dependencies": {
                 "minimatch": "^10.0.3"
             },
@@ -1929,6 +1943,7 @@
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
             "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "acorn": "^8.14.0",
                 "acorn-import-attributes": "^1.9.5",
@@ -1936,36 +1951,31 @@
                 "module-details-from-path": "^1.0.3"
             }
         },
-        "node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "engines": {
-                "node": ">=0.8.19"
-            }
-        },
         "node_modules/ini": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
             "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 12"
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1978,6 +1988,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -1986,6 +1997,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -1997,6 +2009,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
             "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=20"
             }
@@ -2005,6 +2018,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
             "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+            "license": "MIT",
             "peerDependencies": {
                 "ws": "*"
             }
@@ -2025,9 +2039,10 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-            "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
@@ -2036,6 +2051,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -2047,19 +2063,16 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 10.16.0"
             }
-        },
-        "node_modules/json-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
             "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "license": "MIT",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -2068,6 +2081,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
             "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+            "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
@@ -2078,12 +2092,14 @@
             "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
             "engines": [
                 "node >= 0.2.0"
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/jsonpath-plus": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
-            "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+            "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+            "license": "MIT",
             "dependencies": {
                 "@jsep-plugin/assignment": "^1.3.0",
                 "@jsep-plugin/regex": "^1.0.4",
@@ -2100,53 +2116,45 @@
         "node_modules/just-diff": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
-            "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA=="
+            "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+            "license": "MIT"
         },
         "node_modules/just-diff-apply": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
-            "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw=="
-        },
-        "node_modules/keyv": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "dependencies": {
-                "json-buffer": "3.0.1"
-            }
+            "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+            "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "license": "MIT"
         },
         "node_modules/long": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
-        },
-        "node_modules/lowercase-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-            "engines": {
-                "node": ">=8"
-            }
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
-            "version": "11.2.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }
         },
         "node_modules/make-fetch-happen": {
-            "version": "15.0.3",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.3.tgz",
-            "integrity": "sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==",
+            "version": "15.0.5",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+            "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+            "license": "ISC",
             "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
                 "@npmcli/agent": "^4.0.0",
+                "@npmcli/redact": "^4.0.0",
                 "cacache": "^20.0.1",
                 "http-cache-semantics": "^4.1.1",
                 "minipass": "^7.0.2",
@@ -2155,7 +2163,6 @@
                 "minipass-pipeline": "^1.2.4",
                 "negotiator": "^1.0.0",
                 "proc-log": "^6.0.0",
-                "promise-retry": "^2.0.1",
                 "ssri": "^13.0.0"
             },
             "engines": {
@@ -2166,6 +2173,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -2173,12 +2181,14 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "license": "MIT"
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2187,6 +2197,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -2198,27 +2209,21 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/minimatch": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-            "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -2228,14 +2233,16 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -2244,6 +2251,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
             "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+            "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
             },
@@ -2252,9 +2260,10 @@
             }
         },
         "node_modules/minipass-fetch": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.1.tgz",
-            "integrity": "sha512-yHK8pb0iCGat0lDrs/D6RZmCdaBT64tULXjdxjSMAqoDi18Q3qKEUTHypHQZQd9+FYpIS+lkvpq6C/R6SbUeRw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+            "license": "MIT",
             "dependencies": {
                 "minipass": "^7.0.3",
                 "minipass-sized": "^2.0.0",
@@ -2264,13 +2273,14 @@
                 "node": "^20.17.0 || >=22.9.0"
             },
             "optionalDependencies": {
-                "encoding": "^0.1.13"
+                "iconv-lite": "^0.7.2"
             }
         },
         "node_modules/minipass-flush": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-            "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+            "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -2282,6 +2292,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -2292,12 +2303,14 @@
         "node_modules/minipass-flush/node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
         },
         "node_modules/minipass-pipeline": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
             "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+            "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
             },
@@ -2309,6 +2322,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -2319,12 +2333,14 @@
         "node_modules/minipass-pipeline/node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
         },
         "node_modules/minipass-sized": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
             "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+            "license": "ISC",
             "dependencies": {
                 "minipass": "^7.1.2"
             },
@@ -2336,6 +2352,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
             "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "license": "MIT",
             "dependencies": {
                 "minipass": "^7.1.2"
             },
@@ -2346,17 +2363,20 @@
         "node_modules/module-details-from-path": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/negotiator": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
             "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2365,6 +2385,7 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -2381,19 +2402,20 @@
             }
         },
         "node_modules/node-gyp": {
-            "version": "12.2.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
-            "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+            "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+            "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
                 "exponential-backoff": "^3.1.1",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^15.0.0",
                 "nopt": "^9.0.0",
                 "proc-log": "^6.0.0",
                 "semver": "^7.3.5",
                 "tar": "^7.5.4",
                 "tinyglobby": "^0.2.12",
+                "undici": "^6.25.0",
                 "which": "^6.0.0"
             },
             "bin": {
@@ -2407,6 +2429,7 @@
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
             "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+            "license": "ISC",
             "dependencies": {
                 "abbrev": "^4.0.0"
             },
@@ -2421,6 +2444,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
             "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^7.0.0",
                 "semver": "^7.3.5",
@@ -2434,6 +2458,7 @@
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
             "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^10.0.1"
             },
@@ -2444,23 +2469,14 @@
         "node_modules/normalize-package-data/node_modules/lru-cache": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-        },
-        "node_modules/normalize-url": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
         },
         "node_modules/npm-bundled": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
             "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+            "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^5.0.0"
             },
@@ -2472,6 +2488,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
             "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "semver": "^7.1.1"
             },
@@ -2483,6 +2500,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
             "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -2491,6 +2509,7 @@
             "version": "13.0.2",
             "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
             "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+            "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^9.0.0",
                 "proc-log": "^6.0.0",
@@ -2502,9 +2521,10 @@
             }
         },
         "node_modules/npm-packlist": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.3.tgz",
-            "integrity": "sha512-zPukTwJMOu5X5uvm0fztwS5Zxyvmk38H/LfidkOMt3gbZVCyro2cD/ETzwzVPcWZA3JOyPznfUN/nkyFiyUbxg==",
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+            "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+            "license": "ISC",
             "dependencies": {
                 "ignore-walk": "^8.0.0",
                 "proc-log": "^6.0.0"
@@ -2517,6 +2537,7 @@
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
             "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "license": "ISC",
             "dependencies": {
                 "npm-install-checks": "^8.0.0",
                 "npm-normalize-package-bin": "^5.0.0",
@@ -2531,6 +2552,7 @@
             "version": "19.1.1",
             "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
             "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+            "license": "ISC",
             "dependencies": {
                 "@npmcli/redact": "^4.0.0",
                 "jsonparse": "^1.3.1",
@@ -2549,6 +2571,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -2557,9 +2580,10 @@
             }
         },
         "node_modules/oauth4webapi": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.4.tgz",
-            "integrity": "sha512-EKlVEgav8zH31IXxvhCqjEgQws6S9QmnmJyLXmeV5REf59g7VmqRVa5l/rhGWtUqGm2rLVTNwukn9hla5kJ2WQ==",
+            "version": "3.8.6",
+            "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+            "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
@@ -2568,6 +2592,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
             }
@@ -2576,6 +2601,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -2587,43 +2613,23 @@
             }
         },
         "node_modules/openid-client": {
-            "version": "6.8.2",
-            "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.2.tgz",
-            "integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
+            "version": "6.8.4",
+            "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+            "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+            "license": "MIT",
             "dependencies": {
-                "jose": "^6.1.3",
-                "oauth4webapi": "^3.8.4"
+                "jose": "^6.2.2",
+                "oauth4webapi": "^3.8.5"
             },
             "funding": {
                 "url": "https://github.com/sponsors/panva"
-            }
-        },
-        "node_modules/p-cancelable": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-            "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/p-map": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
             "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/package-directory": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/package-directory/-/package-directory-8.2.0.tgz",
-            "integrity": "sha512-qJSu5Mo6tHmRxCy2KCYYKYgcfBdUpy9dwReaZD/xwf608AUk/MoRtIOWzgDtUeGeC7n/55yC3MI1Q+MbSoektw==",
-            "dependencies": {
-                "find-up-simple": "^1.0.0"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -2638,10 +2644,12 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pacote": {
-            "version": "21.3.1",
-            "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.3.1.tgz",
-            "integrity": "sha512-O0EDXi85LF4AzdjG74GUwEArhdvawi/YOHcsW6IijKNj7wm8IvEWNF5GnfuxNpQ/ZpO3L37+v8hqdVh8GgWYhg==",
+            "version": "21.5.0",
+            "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.0.tgz",
+            "integrity": "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==",
+            "license": "ISC",
             "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
                 "@npmcli/git": "^7.0.0",
                 "@npmcli/installed-package-contents": "^4.0.0",
                 "@npmcli/package-json": "^7.0.0",
@@ -2655,7 +2663,6 @@
                 "npm-pick-manifest": "^11.0.1",
                 "npm-registry-fetch": "^19.0.0",
                 "proc-log": "^6.0.0",
-                "promise-retry": "^2.0.1",
                 "sigstore": "^4.0.0",
                 "ssri": "^13.0.0",
                 "tar": "^7.4.3"
@@ -2671,6 +2678,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
             "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+            "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^5.0.0",
                 "just-diff": "^6.0.0",
@@ -2684,6 +2692,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -2691,7 +2700,8 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
         },
         "node_modules/path-scurry": {
             "version": "2.0.2",
@@ -2710,11 +2720,12 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-            "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -2724,6 +2735,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -2736,6 +2748,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
             "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -2744,6 +2757,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
             "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -2752,6 +2766,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
             "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+            "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
@@ -2760,38 +2775,28 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
             "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+            "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/promise-retry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-            "dependencies": {
-                "err-code": "^2.0.2",
-                "retry": "^0.12.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+            "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
             "hasInstallScript": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/codegen": "^2.0.5",
                 "@protobufjs/eventemitter": "^1.1.0",
                 "@protobufjs/fetch": "^1.1.0",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/inquire": "^1.1.1",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
                 "long": "^5.0.0"
             },
@@ -2800,29 +2805,20 @@
             }
         },
         "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
-            }
-        },
-        "node_modules/quick-lru": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/read-cmd-shim": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
             "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -2831,6 +2827,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2839,6 +2836,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2847,6 +2845,7 @@
             "version": "7.5.2",
             "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
             "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+            "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.5",
                 "module-details-from-path": "^1.0.3",
@@ -2857,10 +2856,12 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "license": "MIT",
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
@@ -2875,45 +2876,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-alpn": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
-        },
-        "node_modules/responselike": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-            "dependencies": {
-                "lowercase-keys": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/rfc4648": {
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
-            "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="
+            "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+            "license": "MIT"
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT",
             "optional": true
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2925,6 +2905,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -2936,6 +2917,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -2944,6 +2926,7 @@
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
             "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2954,17 +2937,20 @@
         "node_modules/shimmer": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
         },
         "node_modules/sigstore": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.0.tgz",
             "integrity": "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^4.0.0",
                 "@sigstore/core": "^3.1.0",
@@ -2981,17 +2967,19 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
             }
         },
         "node_modules/socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+            "license": "MIT",
             "dependencies": {
-                "ip-address": "^10.0.1",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -3003,6 +2991,7 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -3016,6 +3005,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3024,6 +3014,7 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -3033,39 +3024,55 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
             "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
             }
         },
         "node_modules/spdx-exceptions": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "license": "CC-BY-3.0"
         },
         "node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "license": "MIT",
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "license": "CC0-1.0"
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/ssri": {
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
             "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+            "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
             },
@@ -3077,24 +3084,53 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
             "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+            "license": "Unlicense",
             "engines": {
                 "node": ">= 0.10.0"
             }
         },
         "node_modules/streamx": {
-            "version": "2.23.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-            "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+            "version": "2.25.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+            "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+            "license": "MIT",
             "dependencies": {
                 "events-universal": "^1.0.0",
                 "fast-fifo": "^1.3.2",
                 "text-decoder": "^1.1.0"
             }
         },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -3103,6 +3139,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3111,9 +3148,10 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-            "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+            "version": "7.5.15",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+            "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
                 "chownr": "^3.0.0",
@@ -3126,9 +3164,10 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-            "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+            "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+            "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
@@ -3139,30 +3178,43 @@
             }
         },
         "node_modules/tar-stream": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+            "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+            "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
+                "bare-fs": "^4.5.5",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
         },
+        "node_modules/teex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+            "license": "MIT",
+            "dependencies": {
+                "streamx": "^2.12.5"
+            }
+        },
         "node_modules/text-decoder": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.4.tgz",
-            "integrity": "sha512-mzlffA3tBNhziEHPK5L5InZg1d/ElNIpJhnhbDRNUtem/edZcJ5zg5FgwKKKOyklxk+6Jt+TrSu83musmvrDlg==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -3171,21 +3223,11 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
-        "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/tmp": {
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
             "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14.14"
             }
@@ -3193,12 +3235,14 @@
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/treeverse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
             "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+            "license": "ISC",
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -3207,6 +3251,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
             "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+            "license": "MIT",
             "dependencies": {
                 "@tufjs/models": "4.1.0",
                 "debug": "^4.4.3",
@@ -3220,7 +3265,8 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "devOptional": true,
+            "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3229,37 +3275,26 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/undici": {
+            "version": "6.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+            "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
-        },
-        "node_modules/unique-filename": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
-            "integrity": "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==",
-            "dependencies": {
-                "unique-slug": "^6.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/unique-slug": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-6.0.0.tgz",
-            "integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "license": "MIT"
         },
         "node_modules/upath": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=4",
                 "yarn": "*"
@@ -3268,21 +3303,34 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "license": "MIT"
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "node_modules/validate-npm-package-name": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
             "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -3291,6 +3339,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
             "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+            "license": "ISC",
             "engines": {
                 "node": "20 || >=22"
             }
@@ -3298,12 +3347,14 @@
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -3313,6 +3364,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
             "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "license": "ISC",
             "dependencies": {
                 "isexe": "^4.0.0"
             },
@@ -3323,17 +3375,35 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
         },
         "node_modules/write-file-atomic": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.0.tgz",
-            "integrity": "sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+            "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+            "license": "ISC",
             "dependencies": {
-                "imurmurhash": "^0.1.4",
                 "signal-exit": "^4.0.1"
             },
             "engines": {
@@ -3344,6 +3414,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "license": "ISC",
             "engines": {
                 "node": ">=14"
             },
@@ -3352,9 +3423,10 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -3375,6 +3447,7 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
@@ -3383,6 +3456,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
             "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
             }
@@ -3391,6 +3465,7 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -3408,45 +3483,9 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "license": "ISC",
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/yargs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         }
     }

--- a/examples/db+k8s/package-lock.json
+++ b/examples/db+k8s/package-lock.json
@@ -7,13 +7,13 @@
             "name": "upcloud-typescript",
             "dependencies": {
                 "@kubernetes/client-node": "^1.4.0",
-                "@pulumi/kubernetes": "^4.28.0",
-                "@pulumi/pulumi": "^3.224.0",
-                "@upcloud/pulumi-upcloud": "^0.11.1"
+                "@pulumi/kubernetes": "^4.32.0",
+                "@pulumi/pulumi": "^3.250.0",
+                "@upcloud/pulumi-upcloud": "^0.15.0"
             },
             "devDependencies": {
                 "@types/node": "^18.19.130",
-                "typescript": "^5.9.3"
+                "typescript": "^6.0.3"
             }
         },
         "node_modules/@gar/promise-retry": {
@@ -803,9 +803,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@pulumi/kubernetes": {
-            "version": "4.30.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-4.30.0.tgz",
-            "integrity": "sha512-ZCS4HwBvcxfdPDw44L1/SCqoIttCVugx/FZzqRFRq+leKRIfigAYt4sILXlqulNtX6XjlWVzZO8zva3Ygk7hGA==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-4.32.0.tgz",
+            "integrity": "sha512-JMzaG8BI+nsHzcOwFEbmueyn2HN4HrLv1znVAKS0vPgLrlSAc+WDsaRUxQnHBE37+3RL3r4mipUemRCIe8Xvww==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -815,9 +815,9 @@
             }
         },
         "node_modules/@pulumi/pulumi": {
-            "version": "3.237.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.237.0.tgz",
-            "integrity": "sha512-sSha6qfV1dcLP6OkqLKyM1UdzKRLfcAsHfhAUiXhlSHia+Grsso1Zvq0ZByj44nK9sY98BLlPlQBtt1VRWHZOQ==",
+            "version": "3.250.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.250.0.tgz",
+            "integrity": "sha512-/CaE4gWlOGNFt9eWxip2SscL1Nh1i9ZzzFSkjbrNQol5u9dOjGWNzWlOCerA6riH0603MkT9xNlRnJ4TGstXrw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.1",
@@ -833,23 +833,19 @@
                 "@opentelemetry/sdk-trace-node": "^1.30",
                 "@types/google-protobuf": "^3.15.5",
                 "@types/semver": "^7.5.6",
-                "@types/tmp": "^0.2.6",
                 "execa": "^5.1.0",
-                "fdir": "^6.5.0",
                 "google-protobuf": "^3.21.4",
                 "ini": "^2.0.0",
-                "js-yaml": "^3.14.2",
+                "js-yaml": "^4.0.0",
                 "minimist": "^1.2.6",
                 "normalize-package-data": "^6.0.0",
-                "picomatch": "^4.0.0",
                 "require-from-string": "^2.0.1",
                 "semver": "^7.5.2",
                 "source-map-support": "^0.5.6",
-                "tmp": "^0.2.4",
                 "upath": "^1.1.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "ts-node": ">= 7.0.1 < 12",
@@ -862,28 +858,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@pulumi/pulumi/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/@pulumi/pulumi/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@sigstore/bundle": {
@@ -1034,16 +1008,10 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/tmp": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
-            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
-            "license": "MIT"
-        },
         "node_modules/@upcloud/pulumi-upcloud": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/@upcloud/pulumi-upcloud/-/pulumi-upcloud-0.11.1.tgz",
-            "integrity": "sha512-uqjOAQGo/5oznzrTsOuxlFqXd5PLGIvpYWMdzDeYGjVu5S/+HMGAzxzSQ7MJJbjdHLUsdaY1DZoIYFZTvlpB2g==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@upcloud/pulumi-upcloud/-/pulumi-upcloud-0.15.0.tgz",
+            "integrity": "sha512-1nBh5JSRE7M84qd6pwaPwTY2SeCmMp5SIiIW9cGw/pCG+8R1ds2n0W6tzG7Po6QrL4OaauHnWFqmhzxeibAb1A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@pulumi/pulumi": "^3.142.0"
@@ -1563,19 +1531,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/events-universal": {
@@ -3062,12 +3017,6 @@
             "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "license": "CC0-1.0"
         },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/ssri": {
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
@@ -3223,15 +3172,6 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
-        "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -3262,10 +3202,10 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/examples/db+k8s/package.json
+++ b/examples/db+k8s/package.json
@@ -1,14 +1,15 @@
 {
     "name": "upcloud-typescript",
     "main": "index.ts",
+    "type": "module",
     "devDependencies": {
-        "@types/node": "^18.0.0",
-        "typescript": "^5.0.0"
+        "@types/node": "^18.19.130",
+        "typescript": "^5.9.3"
     },
     "dependencies": {
-        "@kubernetes/client-node": "^1.1.2",
+        "@kubernetes/client-node": "^1.4.0",
         "@pulumi/kubernetes": "^4.28.0",
-        "@pulumi/pulumi": "^3.0.0",
-        "@upcloud/pulumi-upcloud": "^0.2.0"
+        "@pulumi/pulumi": "^3.224.0",
+        "@upcloud/pulumi-upcloud": "^0.11.1"
     }
 }

--- a/examples/db+k8s/package.json
+++ b/examples/db+k8s/package.json
@@ -4,12 +4,16 @@
     "type": "module",
     "devDependencies": {
         "@types/node": "^18.19.130",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
     },
     "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
-        "@pulumi/kubernetes": "^4.28.0",
-        "@pulumi/pulumi": "^3.224.0",
-        "@upcloud/pulumi-upcloud": "^0.11.1"
+        "@pulumi/kubernetes": "^4.32.0",
+        "@pulumi/pulumi": "^3.250.0",
+        "@upcloud/pulumi-upcloud": "^0.15.0"
+    },
+    "allowScripts": {
+        "@pulumi/kubernetes@4.32.0": true,
+        "protobufjs@7.5.8": true
     }
 }

--- a/examples/db+k8s/tsconfig.json
+++ b/examples/db+k8s/tsconfig.json
@@ -1,18 +1,14 @@
 {
     "compilerOptions": {
+        "target": "esnext",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "allowImportingTsExtensions": true,
+        "noEmit": true,
+
         "strict": true,
-        "outDir": "bin",
-        "target": "es2020",
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "sourceMap": true,
-        "experimentalDecorators": true,
-        "pretty": true,
         "noFallthroughCasesInSwitch": true,
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.ts"
-    ]
+    }
 }


### PR DESCRIPTION
This is more of a "demo PR".
Because as I was experimenting with this example, I refactored it. But a lot of this is up to taste, so I don't know how much you'd be interested in merging.
One thing that seems to be an objective improvement though (reliability and type safety) is the use of `getKubernetesClusterOutput`.

Why I changed other things that are more subjective:
- Using a function instead of a class (for app deployment) for easier maintainability. Almost nothing was shared across the class and it wasn't instantiated multiple times.
- Use of ESM - allows for top-level await and IMO best practice these days.

One thing that I recognize as awkward is `namespaceName: namespace,` but I couldn't think of anything better that avoids shadowing inside of `createFeedbackApp`.

If you only want to merge part of it, just let me know what I should revert.